### PR TITLE
systemd: correctly match Exec lines with equal signs

### DIFF
--- a/systemd/systemd-vrf-generator
+++ b/systemd/systemd-vrf-generator
@@ -61,7 +61,7 @@ create_instance_sysv()
 	(
 	echo "# ${VRFGEN_NOTE}"
 	while read line; do
-		if [[ $line =~ ("Exec".*=[[:space:]]*[^/]*)(\/.*) ]]; then
+		if [[ $line =~ (Exec[^=]+=[[:space:]]*[^/]*)(\/.*) ]]; then
 			# use full match here to keep all context
 			echo "${BASH_REMATCH[1]}/bin/ip vrf exec %i ${BASH_REMATCH[2]}"
 		else
@@ -104,7 +104,7 @@ handle_overrides()
 		echo "# ${VRFGEN_NOTE}"
 
 		while read line; do
-			if [[ $line =~ ("Exec".*=[[:space:]]*[^/]*)(\/.*) ]]; then
+			if [[ $line =~ (Exec[^=]+=[[:space:]]*[^/]*)(\/.*) ]]; then
 				[ -z "${BASH_REMATCH[2]}" ] && continue
 				# use full match here to keep all context
 				echo "${BASH_REMATCH[1]}/bin/ip vrf exec %i ${BASH_REMATCH[2]}"
@@ -142,7 +142,7 @@ create_vrf_override()
 	echo
 	echo "[Service]"
 	while read line; do
-		if [[ $line =~ ("Exec".*=[[:space:]]*[^/]*)(\/.*) ]]; then
+		if [[ $line =~ (Exec[^=]+=[[:space:]]*[^/]*)(\/.*) ]]; then
 			# directive is the part before the '='
 			set -- ${BASH_REMATCH[1]/=*}
 			d=${1}


### PR DESCRIPTION
If a unit file contained an Exec statement like this one:

```
ExecStart=/bin/example --option=/file
```

`systemd-vrf-generator` would turn it into

```
ExecStart=/bin/example --option=/usr/bin/vrf task exec %i /file
```

because the regex considers everything up to `=/` to be the directive.

This commit modifies the regex to only match up to the first equal sign
on the line.