### PR TITLE
Fix FIB rule for DNS server to match iif loopback

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,6 @@ Description: Linux tools for VRF
 
 Package: mgmt-vrf
 Architecture: all
-Depends: vrf, python, libpam-script, ${misc:Depends}
+Depends: vrf, python, python-pyinotify, libpam-script, ${misc:Depends}
 Description: Linux tools and config for Management VRF
  This package provides tools for using the Management VRF configuration.

--- a/lib-mgmt-vrf/dns-watcher.py
+++ b/lib-mgmt-vrf/dns-watcher.py
@@ -51,7 +51,7 @@ class DNSWatcherActions():
                 if not line: continue
                 l = line.split()
                 mutex.acquire(1)
-                _nameservers.append({'ip': l[4], 'prio': l[0][:-1], 'vrf': l[6]})
+                _nameservers.append({'ip': l[4], 'prio': l[0][:-1], 'vrf': l[8]})
                 mutex.release()
         except subprocess.CalledProcessError as e:
             log.warning(str(e))
@@ -136,7 +136,7 @@ class DNSWatcherActions():
     def modify_rules(action, rules, callback):
         for r in rules:
             try:
-                cmd = 'ip rule %s prio %s to %s' % (action, r['prio'], r['ip'])
+                cmd = 'ip rule %s prio %s to %s iif lo' % (action, r['prio'], r['ip'])
                 if r['vrf']:
                     cmd = '%s table %s' % (cmd, r['vrf'])
                 log.info('executing: %s' % cmd)

--- a/lib-vrf/vrf-dns-helper.c
+++ b/lib-vrf/vrf-dns-helper.c
@@ -35,6 +35,7 @@
 #include <netlink/route/link/vrf.h>
 
 #define RESOLVCONF	"/etc/resolv.conf"
+#define IIF_LOOPBACK	"lo"
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
 
@@ -102,6 +103,7 @@ static struct rtnl_rule *create_rule(struct nl_addr *addr, uint32_t table)
 		rtnl_rule_set_table(rule, table);
 		rtnl_rule_set_action(rule, RTN_UNICAST);
 		rtnl_rule_set_dst(rule, addr);
+		rtnl_rule_set_iif(rule, IIF_LOOPBACK);
 	}
 
 	return rule;
@@ -518,3 +520,4 @@ out:
 
 	return rc;
 }
+


### PR DESCRIPTION
On some systems running switchdev with mlxsw, the driver forbids installation of non-default FIB rules, except the ones with iif of the loopback netdev:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=05414dd116c549a0b9dd57ee4e73ddd9a0038e41

Example:
root@mellanox:mgmt:\~# /usr/lib/vrf/vrf-helper create mgmt 1001
Failed to add ip rule to 10.0.0.1 lookup 1001 prio 99
root@mellanox:mgmt:\~# ip rule add to 10.0.0.1 lookup 1001 prio 99
Error: mlxsw_spectrum: FIB rules not supported.
root@mellanox:mgmt:\~# ip rule add to 10.0.0.1 lookup 1001 prio 99 iif lo
root@mellanox:mgmt:\~#

This patch set fixes this issue by adding extra match for iif=loopback device to indicate that the FIB rule does not have to be offloaded.