### PR TITLE
Fix deps to use python3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,6 @@ Description: Linux tools for VRF
 
 Package: mgmt-vrf
 Architecture: all
-Depends: vrf, python, python-pyinotify, libpam-script, ${misc:Depends}
+Depends: vrf, python3 | python, python3-pyinotify | python-pyinotify, libpam-script, ${misc:Depends}
 Description: Linux tools and config for Management VRF
  This package provides tools for using the Management VRF configuration.


### PR DESCRIPTION
Fix deps for mgmt-vrf to use python3/python3-pyinotify as default and use python/python-pyinotify as fallback.
This permit to install this tools under Debian >= 11.